### PR TITLE
Added handlebars to autocompleted languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,11 @@
             {
                 "language": "astro",
                 "path": "./snippets/snippetshtml.code-snippets"
-            }
+            },
+			{
+				"language": "handlebars",
+				"path": "./snippets/snippetshtml.code-snippets"
+			}
         ]
     }
 }


### PR DESCRIPTION
Handlebars is a templating library for rust and is mostly used for generating html. e.g.: https://github.com/sunng87/handlebars-rust/blob/master/examples/render_file/template.hbs